### PR TITLE
Cache children and re-use if onConnected called again

### DIFF
--- a/packages/preactement/package.json
+++ b/packages/preactement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preactement",
-  "version": "1.8.0",
+  "version": "1.8.2",
   "author": "James Hill <contact@jameshill.dev>",
   "homepage": "https://github.com/jahilldev/component-elements/tree/main/packages/preactement#readme",
   "license": "MIT",

--- a/packages/preactement/src/define.ts
+++ b/packages/preactement/src/define.ts
@@ -131,7 +131,7 @@ function onConnected(this: CustomElement) {
   let children = this.__children;
 
   if (!this.__mounted && !this.hasAttribute('server')) {
-    children = h(parseHtml.call(this), {}); 
+    children = h(parseHtml.call(this), {});
   }
 
   this.__properties = { ...this.__slots, ...data, ...attributes };

--- a/packages/preactement/src/define.ts
+++ b/packages/preactement/src/define.ts
@@ -131,7 +131,7 @@ function onConnected(this: CustomElement) {
 
   let children = this.__children;
 
-  if (!children && !this.hasAttribute('server')) {
+  if (!this.__mounted && !this.hasAttribute('server')) {
     children = h(parseHtml.call(this), {});
   }
 

--- a/packages/preactement/src/define.ts
+++ b/packages/preactement/src/define.ts
@@ -27,10 +27,9 @@ function define<P = {}>(
   const { wrapComponent } = options;
   const preRender = typeof window === 'undefined';
   const elementTag = getElementTag(tagName);
-  const customElement = setupElement(child, options);
 
   if (!preRender) {
-    customElements.define(elementTag, customElement);
+    customElements.define(elementTag, setupElement(child, options));
 
     return;
   }
@@ -132,7 +131,7 @@ function onConnected(this: CustomElement) {
   let children = this.__children;
 
   if (!this.__mounted && !this.hasAttribute('server')) {
-    children = h(parseHtml.call(this), {});
+    children = h(parseHtml.call(this), {}); 
   }
 
   this.__properties = { ...this.__slots, ...data, ...attributes };

--- a/packages/preactement/src/define.ts
+++ b/packages/preactement/src/define.ts
@@ -74,7 +74,7 @@ function setupElement<T>(component: ComponentFunction<T>, options: IOptions = {}
       element.__component = component;
       element.__properties = {};
       element.__slots = {};
-      element.__children = [];
+      element.__children = void 0;
       element.__options = options;
 
       return element;
@@ -96,7 +96,7 @@ function setupElement<T>(component: ComponentFunction<T>, options: IOptions = {}
     __component = component;
     __properties = {};
     __slots = {};
-    __children = [];
+    __children = void 0;
     __options = options;
 
     static observedAttributes = ['props', ...attributes];
@@ -129,9 +129,9 @@ function onConnected(this: CustomElement) {
 
   json?.remove();
 
-  let children;
+  let children = this.__children;
 
-  if (!this.hasAttribute('server')) {
+  if (!children && !this.hasAttribute('server')) {
     children = h(parseHtml.call(this), {});
   }
 

--- a/packages/preactement/tests/define.spec.tsx
+++ b/packages/preactement/tests/define.spec.tsx
@@ -283,6 +283,29 @@ describe('define()', () => {
 
       expect(root.innerHTML).toContain(`<h2>${customTitle}</h2><em></em>`);
     });
+
+    it('correctly caches children when moved in the DOM', () => {
+      const customTitle = '<em>customTitle</em>';
+      const customText = 'Lorem ipsum dolor';
+      const html = `<div slot="customTitle">${customTitle}</div><p>${customText}</p>`;
+
+      define('message-thirteen', () => Message);
+
+      const element = document.createElement('message-thirteen');
+      const wrapper = document.createElement('main');
+
+      element.innerHTML = html;
+
+      root.appendChild(element);
+
+      element.remove();
+
+      expect(root.innerHTML).toContain('');
+
+      root.appendChild(wrapper.appendChild(element));
+
+      expect(root.innerHTML).toContain(`<h2>${customTitle}</h2><em></em><p>${customText}</p>`);
+    });
   });
 
   describe('when run in the browser (no "Reflect.construct")', () => {

--- a/packages/preactement/tests/define.spec.tsx
+++ b/packages/preactement/tests/define.spec.tsx
@@ -302,7 +302,8 @@ describe('define()', () => {
 
       expect(root.innerHTML).toContain('');
 
-      root.appendChild(wrapper.appendChild(element));
+      root.appendChild(wrapper);
+      wrapper.appendChild(element);
 
       expect(root.innerHTML).toContain(`<h2>${customTitle}</h2><em></em><p>${customText}</p>`);
     });

--- a/packages/reactement/package.json
+++ b/packages/reactement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactement",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "author": "James Hill <contact@jameshill.dev>",
   "homepage": "https://github.com/jahilldev/component-elements/tree/main/packages/reactement#readme",
   "license": "MIT",

--- a/packages/reactement/src/define.ts
+++ b/packages/reactement/src/define.ts
@@ -132,7 +132,7 @@ function onConnected(this: CustomElement) {
 
   let children = this.__children;
 
-  if (!children && !this.hasAttribute('server')) {
+  if (!this.__mounted && !this.hasAttribute('server')) {
     children = createElement(parseHtml.call(this), {});
   }
 

--- a/packages/reactement/src/define.ts
+++ b/packages/reactement/src/define.ts
@@ -28,10 +28,9 @@ function define<P = {}>(
   const { wrapComponent } = options;
   const preRender = typeof window === 'undefined';
   const elementTag = getElementTag(tagName);
-  const customElement = setupElement(child, options);
 
   if (!preRender) {
-    customElements.define(elementTag, customElement);
+    customElements.define(elementTag, setupElement(child, options););
 
     return;
   }

--- a/packages/reactement/src/define.ts
+++ b/packages/reactement/src/define.ts
@@ -75,7 +75,7 @@ function setupElement<T>(component: ComponentFunction<T>, options: IOptions = {}
       element.__component = component;
       element.__properties = {};
       element.__slots = {};
-      element.__children = [];
+      element.__children = void 0;
       element.__options = options;
 
       return element;
@@ -97,7 +97,7 @@ function setupElement<T>(component: ComponentFunction<T>, options: IOptions = {}
     __component = component;
     __properties = {};
     __slots = {};
-    __children = [];
+    __children = void 0;
     __options = options;
 
     static observedAttributes = ['props', ...attributes];
@@ -130,9 +130,9 @@ function onConnected(this: CustomElement) {
 
   json?.remove();
 
-  let children;
+  let children = this.__children;
 
-  if (!this.hasAttribute('server')) {
+  if (!children && !this.hasAttribute('server')) {
     children = createElement(parseHtml.call(this), {});
   }
 

--- a/packages/reactement/src/define.ts
+++ b/packages/reactement/src/define.ts
@@ -30,7 +30,7 @@ function define<P = {}>(
   const elementTag = getElementTag(tagName);
 
   if (!preRender) {
-    customElements.define(elementTag, setupElement(child, options););
+    customElements.define(elementTag, setupElement(child, options));
 
     return;
   }

--- a/packages/reactement/tests/define.spec.tsx
+++ b/packages/reactement/tests/define.spec.tsx
@@ -283,6 +283,29 @@ describe('define()', () => {
 
       expect(root.innerHTML).toContain(`<h2>${customTitle}</h2><em></em>`);
     });
+
+    it('correctly caches children when moved in the DOM', () => {
+      const customTitle = '<em>customTitle</em>';
+      const customText = 'Lorem ipsum dolor';
+      const html = `<div slot="customTitle">${customTitle}</div><p>${customText}</p>`;
+
+      define('message-thirteen', () => Message);
+
+      const element = document.createElement('message-thirteen');
+      const wrapper = document.createElement('main');
+
+      element.innerHTML = html;
+
+      root.appendChild(element);
+
+      element.remove();
+
+      expect(root.innerHTML).toContain('');
+
+      root.appendChild(wrapper.appendChild(element));
+
+      expect(root.innerHTML).toContain(`<h2>${customTitle}</h2><em></em><p>${customText}</p>`);
+    });
   });
 
   describe('when run in the browser (no "Reflect.construct")', () => {

--- a/packages/reactement/tests/define.spec.tsx
+++ b/packages/reactement/tests/define.spec.tsx
@@ -302,7 +302,8 @@ describe('define()', () => {
 
       expect(root.innerHTML).toContain('');
 
-      root.appendChild(wrapper.appendChild(element));
+      root.appendChild(wrapper);
+      wrapper.appendChild(element);
 
       expect(root.innerHTML).toContain(`<h2>${customTitle}</h2><em></em><p>${customText}</p>`);
     });

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -42,7 +42,7 @@ interface CustomElement<C = any, I = any> extends HTMLElement {
   __properties?: IProps;
   __slots?: { [index: string]: any };
   __instance?: I;
-  __children?: any[];
+  __children?: any;
   __options: IOptions;
 }
 


### PR DESCRIPTION
Currently when a custom element's `onConnected` callback is invoked, we're clearing the `innerHTML` to avoid it interfering with the (p)react component's render structure. If a component is then moved in the DOM, it will trigger the custom elements lifecycle methods again, this time however, there is no nested HTML to assign to `this.props.children`, so it's undefined on the subsequent render.

The changes in this PR first checks for an assigned value for `this.props.children`, and makes use of that if already defined, caching the result from the previous render.