### PR TITLE
fix: corrected externals to prevent preact bundling

### DIFF
--- a/packages/preactement/package.json
+++ b/packages/preactement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preactement",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "author": "James Hill <contact@jameshill.dev>",
   "homepage": "https://github.com/jahilldev/component-elements/tree/main/packages/preactement#readme",
   "license": "MIT",

--- a/packages/preactement/webpack.config.ts
+++ b/packages/preactement/webpack.config.ts
@@ -23,7 +23,12 @@ const defaultConfig = {
   entry: {
     define: path.join(__dirname, './src/define.ts'),
   },
-  externals: [nodeExternals({ allowlist: ['@component-elements/shared'] })],
+  externals: [
+    nodeExternals({
+      allowlist: ['@component-elements/shared'],
+      modulesDir: path.resolve(__dirname, '../../node_modules'),
+    }),
+  ],
   context: path.join(__dirname, './src'),
   output: {
     path: path.join(__dirname, './dist'),

--- a/packages/reactement/package.json
+++ b/packages/reactement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactement",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": "James Hill <contact@jameshill.dev>",
   "homepage": "https://github.com/jahilldev/component-elements/tree/main/packages/reactement#readme",
   "license": "MIT",

--- a/packages/reactement/webpack.config.ts
+++ b/packages/reactement/webpack.config.ts
@@ -23,7 +23,12 @@ const defaultConfig = {
   entry: {
     define: path.join(__dirname, './src/define.ts'),
   },
-  externals: [nodeExternals({ allowlist: ['@component-elements/shared'] })],
+  externals: [
+    nodeExternals({
+      allowlist: ['@component-elements/shared'],
+      modulesDir: path.resolve(__dirname, '../../node_modules'),
+    }),
+  ],
   context: path.join(__dirname, './src'),
   output: {
     path: path.join(__dirname, './dist'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6396,15 +6396,10 @@ moo@^0.5.0:
   resolved "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz"
   integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
 
-ms@2.1.2:
+ms@2.1.2, ms@^2.0.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-ms@^2.0.0:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multimatch@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
- Updated webpack externals config to account for new Lerna version
- Preact was being incorrectly bundled due to module resolution