### PR TITLE
chore: updated CI to use Node 18 LTS

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,7 @@ jobs:
         id: check
         with:
           file-name: ./packages/${{ matrix.package }}/package.json
-          file-url: https://cdn.jsdelivr.net/npm/@minimal-analytics/${{ matrix.package }}@latest/package.json
+          file-url: https://cdn.jsdelivr.net/npm/${{ matrix.package }}@latest/package.json
           static-checking: localIsNew
 
       - name: Version update detected

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,80 @@
+name: CD
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '18.x'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Cached dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('yarn.lock') }}
+          restore-keys: npm-
+
+      - name: Installing dependencies
+        run: yarn
+
+      - name: Linting codebase
+        run: yarn lint
+
+      - name: Building packages
+        run: yarn build
+
+      - name: Running unit tests
+        run: yarn test
+
+      - name: Cache built packages
+        uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: build-test
+    strategy:
+      matrix: { package: ['preactement', 'reactement'] }
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '18.x'
+          registry-url: https://registry.npmjs.org/
+
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+      - name: Check version changes
+        uses: EndBug/version-check@v1
+        id: check
+        with:
+          file-name: ./packages/${{ matrix.package }}/package.json
+          file-url: https://cdn.jsdelivr.net/npm/@minimal-analytics/${{ matrix.package }}@latest/package.json
+          static-checking: localIsNew
+
+      - name: Version update detected
+        if: steps.check.outputs.changed == 'true'
+        run: 'echo "Version change found! New version: ${{ steps.check.outputs.version }} (${{ steps.check.outputs.type }})"'
+
+      - name: Publishing package
+        if: steps.check.outputs.changed == 'true'
+        run: npm publish
+        working-directory: ./packages/${{ matrix.package }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - name: Cache node modules
         uses: actions/cache@v1
         env:


### PR DESCRIPTION
See the following issue for info: https://github.com/jahilldev/component-elements/issues/24

- Update CI to run Node 18 LTS during build and test phase