### PR TITLE
Removing whitespace stripping functionality

### DIFF
--- a/packages/preactement/src/parse.ts
+++ b/packages/preactement/src/parse.ts
@@ -33,7 +33,7 @@ function parseHtml(this: CustomElement): ComponentFactory<{}> {
 
 function convertToVDom(this: CustomElement, node: Element) {
   if (node.nodeType === 3) {
-    return node.textContent?.trim() || '';
+    return node.textContent || '';
   }
 
   if (node.nodeType !== 1) {

--- a/packages/preactement/tests/parse.spec.ts
+++ b/packages/preactement/tests/parse.spec.ts
@@ -9,6 +9,7 @@ import { parseHtml } from '../src/parse';
  * -------------------------------- */
 
 const testHeading = 'testHeading';
+const testWhitespace = '    ';
 const testHtml = `<h1>${testHeading}</h1><br /><section><h2 title="Main Title">Hello</h2></section>`;
 const testScript = `<script>alert('danger')</script>`;
 
@@ -33,6 +34,14 @@ describe('parse', () => {
       const instance = mount(h(result, {}) as any);
 
       expect(instance.text()).toEqual(testHeading);
+    });
+
+    it('retains whitespace within custom element', () => {
+      const result = parseHtml.call({ innerHTML: testWhitespace });
+		const instance = mount(h(result, {}) as any);
+
+      expect(instance.text()).toEqual(testWhitespace);
+      expect(instance.html()).toEqual(testWhitespace);
     });
 
     it('removes script blocks for security', () => {

--- a/packages/preactement/tests/parse.spec.ts
+++ b/packages/preactement/tests/parse.spec.ts
@@ -9,7 +9,6 @@ import { parseHtml } from '../src/parse';
  * -------------------------------- */
 
 const testHeading = 'testHeading';
-const testWhitespace = '    ';
 const testHtml = `<h1>${testHeading}</h1><br /><section><h2 title="Main Title">Hello</h2></section>`;
 const testScript = `<script>alert('danger')</script>`;
 
@@ -34,14 +33,6 @@ describe('parse', () => {
       const instance = mount(h(result, {}) as any);
 
       expect(instance.text()).toEqual(testHeading);
-    });
-
-    it('handles whitespace within custom element', () => {
-      const result = parseHtml.call({ innerHTML: testWhitespace });
-      const instance = mount(h(result, {}) as any);
-
-      expect(instance.text()).toEqual('');
-      expect(instance.html()).toEqual('');
     });
 
     it('removes script blocks for security', () => {

--- a/packages/preactement/tests/parse.spec.ts
+++ b/packages/preactement/tests/parse.spec.ts
@@ -38,7 +38,7 @@ describe('parse', () => {
 
     it('retains whitespace within custom element', () => {
       const result = parseHtml.call({ innerHTML: testWhitespace });
-		const instance = mount(h(result, {}) as any);
+      const instance = mount(h(result, {}) as any);
 
       expect(instance.text()).toEqual(testWhitespace);
       expect(instance.html()).toEqual(testWhitespace);


### PR DESCRIPTION
Removes `trim()` call and associated test see https://github.com/jahilldev/component-elements/issues/28